### PR TITLE
[Merged by Bors] - Mark `SyntaxNode::new` and `SyntaxToken::new` as `unsafe`

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -18,12 +18,12 @@ static_assertions::assert_eq_size!(SyntaxToken<()>, Option<SyntaxToken<()>>, u64
 
 impl<C: TreeConfig> SyntaxToken<C> {
     #[inline(always)]
-    pub(crate) fn new(idx: u32, tree_id: u32) -> Self {
+    pub(crate) unsafe fn new(idx: u32, tree_id: u32) -> Self {
         Self {
             idx: if cfg!(debug_assertions) {
                 NonZeroU32::new(idx).unwrap()
             } else {
-                unsafe { NonZeroU32::new_unchecked(idx) }
+                NonZeroU32::new_unchecked(idx)
             },
             tree_id,
             phantom: PhantomData,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -275,7 +275,7 @@ impl<C: TreeConfig> SyntaxBuilder<C> {
 impl<C: TreeConfig> SyntaxTree<C> {
     /// Returns the root node of this tree.
     pub fn root(&self) -> SyntaxNode<C> {
-        SyntaxNode::new(self.root_idx(), self.id())
+        unsafe { SyntaxNode::new(self.root_idx(), self.id()) }
     }
 
     /// Returns an iterator over the events stored in this tree.
@@ -387,13 +387,13 @@ impl<C: TreeConfig> Iterator for Events<'_, C> {
         }
 
         if unsafe { self.tree.is_start_node(self.idx) } {
-            let node = SyntaxNode::new(self.idx, self.tree.id());
+            let node = unsafe { SyntaxNode::new(self.idx, self.tree.id()) };
             self.idx += START_NODE_SIZE;
             return Some(Event::StartNode(node));
         }
 
         if unsafe { self.tree.is_add_token(self.idx) } {
-            let token = SyntaxToken::new(self.idx, self.tree.id());
+            let token = unsafe { SyntaxToken::new(self.idx, self.tree.id()) };
             self.idx += ADD_TOKEN_SIZE;
             return Some(Event::AddToken(token));
         }


### PR DESCRIPTION
bors r+