### PR TITLE
[Merged by Bors] - Only run CI on Ubuntu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,7 @@ env:
 jobs:
   rust:
     name: Rust
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,5 @@
 status = [
-  "Rust (ubuntu-latest)",
-  "Rust (windows-latest)",
-  "Rust (macos-latest)",
+  "Rust",
   "Formatting",
 ]
 


### PR DESCRIPTION
Windows is painfully, painfully slow, and I don’t think testing on the three major desktop operating systems will detect any weird portability bugs.

bors r+