### PR TITLE
[Merged by Bors] - Remove `LAST` from `SyntaxKind`

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -9,11 +9,11 @@ use std::fmt::Debug;
 /// This trait is `unsafe` to implement
 /// because you must satisfy the following requirements:
 ///
-/// - all values returned by [`SyntaxKind::to_raw`] must be less than [`SyntaxKind::LAST`]
-/// - [`SyntaxKind::LAST`] must be less than or equal to `0b0111_1111_1111_1110`
+/// - all values returned by [`SyntaxKind::to_raw`]
+///   must be less than or equal to `0b0111_1111_1111_1110`
 ///   ([why?][`crate::SyntaxTree#tag`])
-/// - values must be roundtrippable through [`SyntaxKind::to_raw`], [`SyntaxKind::from_raw`]
-///   and back
+/// - values must be roundtrippable through [`SyntaxKind::to_raw`],
+///   [`SyntaxKind::from_raw`] and back
 ///
 /// Not fulfilling these requirements can result in undefined behaviour.
 ///
@@ -27,39 +27,22 @@ use std::fmt::Debug;
 ///     Struct,
 ///     BinaryExpr,
 ///     CallExpr,
-///     #[doc(hidden)]
-///     __Last, // ⚠️ NOTE ⚠️ passing this variant into to_raw would technically violate
-/// }           // the trait’s contract, but we’ll pretend it’s fine
-///             // because it has two underscores so no one will use it, right??
+/// }
 ///
 /// // SAFETY:
 /// // - we have less than 0b0111_1111_1111_1110 (32,766) enum variants
-/// // - LAST is larger than all variants
 /// // - values returned by to_raw can be passed into from_raw safely
 /// unsafe impl eventree::SyntaxKind for NodeKind {
-///     const LAST: u16 = Self::__Last as u16;
-///
 ///     fn to_raw(self) -> u16 {
 ///         self as u16
 ///     }
 ///
 ///     unsafe fn from_raw(raw: u16) -> Self {
-///         unsafe { std::mem::transmute(raw as u8) }
+///         std::mem::transmute(raw as u8)
 ///     }
 /// }
 /// ```
 pub unsafe trait SyntaxKind: Debug {
-    /// A value larger than all values of your enum.
-    ///
-    /// # Suggested implementation
-    /// It is intended to be your last enum variant,
-    /// so as you add more variants its value increases automatically.
-    ///
-    /// # Contract
-    /// It is up to you, the trait implementor,
-    /// to ensure that this value is less than or equal to `0b0111_1111_1111_1110`.
-    const LAST: u16;
-
     /// Converts your custom type to a `u16`.
     ///
     /// # Suggested implementation
@@ -68,7 +51,7 @@ pub unsafe trait SyntaxKind: Debug {
     ///
     /// # Contract
     /// Part of this trait’s contract is that all values returned by this method
-    /// are less than [`SyntaxKind::LAST`].
+    /// are less than or equal to `0b0111_1111_1111_1110`.
     fn to_raw(self) -> u16;
 
     /// Turns a raw `u16` back into your custom type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,6 @@
 //! enum NodeKind {
 //!     Root,
 //!     BinaryExpr,
-//!     #[doc(hidden)]
-//!     __Last,
 //! }
 //!
 //! #[derive(Debug, PartialEq)]
@@ -55,31 +53,25 @@
 //!     Ident,
 //!     Plus,
 //!     Star,
-//!     #[doc(hidden)]
-//!     __Last,
 //! }
 //!
 //! unsafe impl eventree::SyntaxKind for NodeKind {
-//!     const LAST: u16 = Self::__Last as u16;
-//!
 //!     fn to_raw(self) -> u16 {
 //!         self as u16
 //!     }
 //!
 //!     unsafe fn from_raw(raw: u16) -> Self {
-//!         unsafe { std::mem::transmute(raw as u8) }
+//!         std::mem::transmute(raw as u8)
 //!     }
 //! }
 //!
 //! unsafe impl eventree::SyntaxKind for TokenKind {
-//!     const LAST: u16 = Self::__Last as u16;
-//!
 //!     fn to_raw(self) -> u16 {
 //!         self as u16
 //!     }
 //!
 //!     unsafe fn from_raw(raw: u16) -> Self {
-//!         unsafe { std::mem::transmute(raw as u8) }
+//!         std::mem::transmute(raw as u8)
 //!     }
 //! }
 //! ```
@@ -90,11 +82,11 @@
 //!
 //! ```
 //! # #[derive(Debug, PartialEq)]
-//! # enum NodeKind { Root, BinaryExpr, __Last }
+//! # enum NodeKind { Root, BinaryExpr }
 //! # #[derive(Debug, PartialEq)]
-//! # enum TokenKind { Number, Ident, Plus, Star, __Last }
-//! # unsafe impl eventree::SyntaxKind for NodeKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
-//! # unsafe impl eventree::SyntaxKind for TokenKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
+//! # enum TokenKind { Number, Ident, Plus, Star }
+//! # unsafe impl eventree::SyntaxKind for NodeKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
+//! # unsafe impl eventree::SyntaxKind for TokenKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
 //! #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 //! enum TreeConfig {}
 //!
@@ -109,11 +101,11 @@
 //!
 //! ```
 //! # #[derive(Debug, PartialEq)]
-//! # enum NodeKind { Root, BinaryExpr, __Last }
+//! # enum NodeKind { Root, BinaryExpr }
 //! # #[derive(Debug, PartialEq)]
-//! # enum TokenKind { Number, Ident, Plus, Star, __Last }
-//! # unsafe impl eventree::SyntaxKind for NodeKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
-//! # unsafe impl eventree::SyntaxKind for TokenKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
+//! # enum TokenKind { Number, Ident, Plus, Star }
+//! # unsafe impl eventree::SyntaxKind for NodeKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
+//! # unsafe impl eventree::SyntaxKind for TokenKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
 //! # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 //! # enum TreeConfig {}
 //! # impl eventree::TreeConfig for TreeConfig { type NodeKind = NodeKind; type TokenKind = TokenKind; }
@@ -178,11 +170,11 @@
 //!
 //! ```
 //! # #[derive(Debug, PartialEq)]
-//! # enum NodeKind { Root, BinaryExpr, __Last }
+//! # enum NodeKind { Root, BinaryExpr }
 //! # #[derive(Debug, PartialEq)]
-//! # enum TokenKind { Number, Ident, Plus, Star, __Last }
-//! # unsafe impl eventree::SyntaxKind for NodeKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
-//! # unsafe impl eventree::SyntaxKind for TokenKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
+//! # enum TokenKind { Number, Ident, Plus, Star }
+//! # unsafe impl eventree::SyntaxKind for NodeKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
+//! # unsafe impl eventree::SyntaxKind for TokenKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
 //! # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 //! # enum TreeConfig {}
 //! # impl eventree::TreeConfig for TreeConfig { type NodeKind = NodeKind; type TokenKind = TokenKind; }
@@ -209,11 +201,11 @@
 //!
 //! ```
 //! # #[derive(Debug, PartialEq)]
-//! # enum NodeKind { Root, BinaryExpr, __Last }
+//! # enum NodeKind { Root, BinaryExpr }
 //! # #[derive(Debug, PartialEq)]
-//! # enum TokenKind { Number, Ident, Plus, Star, __Last }
-//! # unsafe impl eventree::SyntaxKind for NodeKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
-//! # unsafe impl eventree::SyntaxKind for TokenKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
+//! # enum TokenKind { Number, Ident, Plus, Star }
+//! # unsafe impl eventree::SyntaxKind for NodeKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
+//! # unsafe impl eventree::SyntaxKind for TokenKind { fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) } }
 //! # #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 //! # enum TreeConfig {}
 //! # impl eventree::TreeConfig for TreeConfig { type NodeKind = NodeKind; type TokenKind = TokenKind; }

--- a/src/node.rs
+++ b/src/node.rs
@@ -361,12 +361,9 @@ mod tests {
         Root,
         BinaryExpr,
         Call,
-        __Last,
     }
 
     unsafe impl crate::SyntaxKind for NodeKind {
-        const LAST: u16 = Self::__Last as u16;
-
         fn to_raw(self) -> u16 {
             self as u16
         }
@@ -382,12 +379,9 @@ mod tests {
         Ident,
         IntLiteral,
         Plus,
-        __Last,
     }
 
     unsafe impl crate::SyntaxKind for TokenKind {
-        const LAST: u16 = Self::__Last as u16;
-
         fn to_raw(self) -> u16 {
             self as u16
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,7 @@
 mod tag;
 
 use self::tag::Tag;
-use crate::{SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TreeConfig};
+use crate::{SyntaxNode, SyntaxToken, TextRange, TreeConfig};
 use std::fmt;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -127,8 +127,6 @@ impl<C: TreeConfig> SyntaxBuilder<C> {
         add_tokens: usize,
         finish_nodes: usize,
     ) -> Self {
-        debug_assert!(C::NodeKind::LAST <= Tag::MAX_KIND);
-        debug_assert!(C::TokenKind::LAST <= Tag::MAX_KIND);
         assert!(text.len() < u32::MAX as usize);
 
         let id = CURRENT_TREE_ID.fetch_add(1, Ordering::SeqCst);
@@ -524,12 +522,9 @@ mod tests {
         Root,
         Block,
         Function,
-        __Last,
     }
 
     unsafe impl crate::SyntaxKind for NodeKind {
-        const LAST: u16 = Self::__Last as u16;
-
         fn to_raw(self) -> u16 {
             self as u16
         }
@@ -549,12 +544,9 @@ mod tests {
         LetKw,
         RBrace,
         Semicolon,
-        __Last,
     }
 
     unsafe impl crate::SyntaxKind for TokenKind {
-        const LAST: u16 = Self::__Last as u16;
-
         fn to_raw(self) -> u16 {
             self as u16
         }

--- a/src/tree/tag.rs
+++ b/src/tree/tag.rs
@@ -5,18 +5,16 @@ use crate::{SyntaxKind, TreeConfig};
 pub(super) struct Tag(u16);
 
 impl Tag {
-    pub(crate) const MAX_KIND: u16 = (u16::MAX >> 1) - 1; // all 1s apart from first and last
+    const MAX_KIND: u16 = (u16::MAX >> 1) - 1; // all 1s apart from first and last
 
     pub(super) fn start_node<C: TreeConfig>(kind: C::NodeKind) -> Self {
         let raw = kind.to_raw();
-        debug_assert!(raw < C::NodeKind::LAST);
         debug_assert!(raw <= Self::MAX_KIND);
         Self(raw | 1 << 15) // set high bit to 1
     }
 
     pub(super) fn add_token<C: TreeConfig>(kind: C::TokenKind) -> Self {
         let raw = kind.to_raw();
-        debug_assert!(raw < C::TokenKind::LAST);
         debug_assert!(raw <= Self::MAX_KIND);
         Self(raw)
     }
@@ -40,14 +38,12 @@ impl Tag {
     pub(super) fn get_start_node_kind<C: TreeConfig>(self) -> C::NodeKind {
         debug_assert!(self.is_start_node());
         let raw = self.0 & u16::MAX >> 1; // zero out high bit
-        debug_assert!(raw < C::NodeKind::LAST);
         debug_assert!(raw <= Self::MAX_KIND);
         unsafe { C::NodeKind::from_raw(raw) }
     }
 
     pub(super) fn get_add_token_kind<C: TreeConfig>(self) -> C::TokenKind {
         debug_assert!(self.is_add_token());
-        debug_assert!(self.0 < C::TokenKind::LAST);
         debug_assert!(self.0 <= Self::MAX_KIND);
         unsafe { C::TokenKind::from_raw(self.0) }
     }

--- a/src/tree_config.rs
+++ b/src/tree_config.rs
@@ -11,11 +11,17 @@ use std::hash::Hash;
 ///
 /// ```
 /// # #[derive(Debug, PartialEq)]
-/// # enum MyNodeKind { Root, __Last }
+/// # enum MyNodeKind { Root, Foo }
 /// # #[derive(Debug, PartialEq)]
-/// # enum MyTokenKind { Foo, __Last }
-/// # unsafe impl eventree::SyntaxKind for MyNodeKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
-/// # unsafe impl eventree::SyntaxKind for MyTokenKind { const LAST: u16 = Self::__Last as u16; fn to_raw(self) -> u16 { self as u16 } unsafe fn from_raw(raw: u16) -> Self { unsafe { std::mem::transmute(raw as u8) } } }
+/// # enum MyTokenKind { Bar, Baz }
+/// # unsafe impl eventree::SyntaxKind for MyNodeKind {
+/// #     fn to_raw(self) -> u16 { self as u16 }
+/// #     unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) }
+/// # }
+/// # unsafe impl eventree::SyntaxKind for MyTokenKind {
+/// #     fn to_raw(self) -> u16 { self as u16 }
+/// #     unsafe fn from_raw(raw: u16) -> Self { std::mem::transmute(raw as u8) }
+/// # }
 /// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// enum TreeConfig {}
 ///


### PR DESCRIPTION
The `debug_assert!`s in `Tag`’s methods are enough.