### PR TITLE
[Merged by Bors] - Rename `range` methods to `text_range`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@
 //! // we can get the kind, text and range of nodes
 //! assert_eq!(root.kind(&tree), NodeKind::Root);
 //! assert_eq!(root.text(&tree), "foo+10*20");
-//! assert_eq!(root.range(&tree), TextRange::new(0.into(), 9.into()));
+//! assert_eq!(root.text_range(&tree), TextRange::new(0.into(), 9.into()));
 //!
 //! // we can get the child nodes in the root; there’s just one, the BinaryExpr
 //! let mut child_nodes = root.child_nodes(&tree);
@@ -248,7 +248,7 @@
 //! let ident = descendant_tokens.next().unwrap();
 //! assert_eq!(ident.kind(&tree), TokenKind::Ident);
 //! assert_eq!(ident.text(&tree), "foo");
-//! assert_eq!(ident.range(&tree), TextRange::new(0.into(), 3.into()));
+//! assert_eq!(ident.text_range(&tree), TextRange::new(0.into(), 3.into()));
 //!
 //! // let’s finish off by going through all descendant tokens
 //! // until we reach the end

--- a/src/node.rs
+++ b/src/node.rs
@@ -115,7 +115,7 @@ impl<C: TreeConfig> SyntaxNode<C> {
     }
 
     /// Returns the range this node spans in the original input.
-    pub fn range(self, tree: &SyntaxTree<C>) -> TextRange {
+    pub fn text_range(self, tree: &SyntaxTree<C>) -> TextRange {
         self.verify_tree(tree);
         let (_, _, start, end) = unsafe { tree.get_start_node(self.idx.get()) };
         TextRange::new(start.into(), end.into())

--- a/src/token.rs
+++ b/src/token.rs
@@ -45,7 +45,7 @@ impl<C: TreeConfig> SyntaxToken<C> {
     }
 
     /// Returns the range this token spans in the original input.
-    pub fn range(self, tree: &SyntaxTree<C>) -> TextRange {
+    pub fn text_range(self, tree: &SyntaxTree<C>) -> TextRange {
         self.verify_tree(tree);
         let (_, start, end) = unsafe { tree.get_add_token(self.idx.get()) };
         TextRange::new(start.into(), end.into())

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -503,7 +503,7 @@ impl<C: TreeConfig> fmt::Debug for SyntaxTree<C> {
                     }
                     indentation_level += 1;
                     let kind = node.kind(self);
-                    let range = node.range(self);
+                    let range = node.text_range(self);
                     writeln!(f, "{kind:?}@{range:?}")?;
                 }
                 Event::AddToken(token) => {
@@ -511,7 +511,7 @@ impl<C: TreeConfig> fmt::Debug for SyntaxTree<C> {
                         write!(f, "  ")?;
                     }
                     let kind = token.kind(self);
-                    let range = token.range(self);
+                    let range = token.text_range(self);
                     let text = token.text(self);
                     writeln!(f, "{kind:?}@{range:?} {text:?}")?;
                 }


### PR DESCRIPTION
bors r+