### PR TITLE
[Merged by Bors] - Revert `tezt_range` back to `range`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@
 //! // we can get the kind, text and range of nodes
 //! assert_eq!(root.kind(&tree), NodeKind::Root);
 //! assert_eq!(root.text(&tree), "foo+10*20");
-//! assert_eq!(root.text_range(&tree), TextRange::new(0.into(), 9.into()));
+//! assert_eq!(root.range(&tree), TextRange::new(0.into(), 9.into()));
 //!
 //! // we can get the child nodes in the root; there’s just one, the BinaryExpr
 //! let mut child_nodes = root.child_nodes(&tree);
@@ -248,7 +248,7 @@
 //! let ident = descendant_tokens.next().unwrap();
 //! assert_eq!(ident.kind(&tree), TokenKind::Ident);
 //! assert_eq!(ident.text(&tree), "foo");
-//! assert_eq!(ident.text_range(&tree), TextRange::new(0.into(), 3.into()));
+//! assert_eq!(ident.range(&tree), TextRange::new(0.into(), 3.into()));
 //!
 //! // let’s finish off by going through all descendant tokens
 //! // until we reach the end

--- a/src/node.rs
+++ b/src/node.rs
@@ -106,7 +106,7 @@ impl<C: TreeConfig> SyntaxNode<C> {
     }
 
     /// Returns the range this node spans in the original input.
-    pub fn text_range(self, tree: &SyntaxTree<C>) -> TextRange {
+    pub fn range(self, tree: &SyntaxTree<C>) -> TextRange {
         self.verify_tree(tree);
         let start_node = unsafe { tree.get_start_node(self.idx) };
         TextRange::new(start_node.start.into(), start_node.end.into())

--- a/src/token.rs
+++ b/src/token.rs
@@ -37,7 +37,7 @@ impl<C: TreeConfig> SyntaxToken<C> {
     }
 
     /// Returns the range this token spans in the original input.
-    pub fn text_range(self, tree: &SyntaxTree<C>) -> TextRange {
+    pub fn range(self, tree: &SyntaxTree<C>) -> TextRange {
         self.verify_tree(tree);
         let add_token = unsafe { tree.get_add_token(self.idx) };
         TextRange::new(add_token.start.into(), add_token.end.into())

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -573,7 +573,7 @@ impl<C: TreeConfig> fmt::Debug for SyntaxTree<C> {
                     }
                     indentation_level += 1;
                     let kind = node.kind(self);
-                    let range = node.text_range(self);
+                    let range = node.range(self);
                     writeln!(f, "{kind:?}@{range:?}")?;
                 }
                 Event::AddToken(token) => {
@@ -581,7 +581,7 @@ impl<C: TreeConfig> fmt::Debug for SyntaxTree<C> {
                         write!(f, "  ")?;
                     }
                     let kind = token.kind(self);
-                    let range = token.text_range(self);
+                    let range = token.range(self);
                     let text = token.text(self);
                     writeln!(f, "{kind:?}@{range:?} {text:?}")?;
                 }


### PR DESCRIPTION
I changed my mind :P

I think the possibility of someone misunderstanding this as the byte range of the node/token in the allocation is very slim. This method is used a lot, so I think it makes sense to prioritise it having a short name.