### PR TITLE
[Merged by Bors] - Add remaining missing `#[repr(u8)]` on enums

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -21,6 +21,7 @@ use std::fmt::Debug;
 ///
 /// ```
 /// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// #[repr(u8)]
 /// enum NodeKind {
 ///     Root,
 ///     Function,

--- a/src/node.rs
+++ b/src/node.rs
@@ -343,6 +343,7 @@ mod tests {
     use crate::SyntaxBuilder;
 
     #[derive(Debug, PartialEq)]
+    #[repr(u8)]
     enum NodeKind {
         Root,
         BinaryExpr,
@@ -360,6 +361,7 @@ mod tests {
     }
 
     #[derive(Debug, PartialEq)]
+    #[repr(u8)]
     enum TokenKind {
         Asterisk,
         Ident,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -609,6 +609,7 @@ mod tests {
     use expect_test::expect;
 
     #[derive(Debug, PartialEq)]
+    #[repr(u8)]
     enum NodeKind {
         Root,
         Block,
@@ -626,6 +627,7 @@ mod tests {
     }
 
     #[derive(Debug, PartialEq)]
+    #[repr(u8)]
     enum TokenKind {
         Arrow,
         Comment,

--- a/src/tree_config.rs
+++ b/src/tree_config.rs
@@ -11,8 +11,10 @@ use std::hash::Hash;
 ///
 /// ```
 /// # #[derive(Debug, PartialEq)]
+/// # #[repr(u8)]
 /// # enum MyNodeKind { Root, Foo }
 /// # #[derive(Debug, PartialEq)]
+/// # #[repr(u8)]
 /// # enum MyTokenKind { Bar, Baz }
 /// # unsafe impl eventree::SyntaxKind for MyNodeKind {
 /// #     fn to_raw(self) -> u16 { self as u16 }


### PR DESCRIPTION
bors r+